### PR TITLE
Initialize TypeScript API template

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,25 @@
   "license": "ISC",
   "author": "",
   "type": "commonjs",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "clean": "rimraf dist",
+    "build": "npm run clean && tsc",
+    "dev": "ts-node src/index.ts",
+    "start": "npm run build && node dist/index.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^5.1.0"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.2",
     "@types/typescript": "^0.4.29",
+    "jest": "^29.7.0",
+    "rimraf": "^5.0.5",
+    "ts-jest": "^29.2.1",
+    "ts-node": "^10.9.1",
     "typescript": "^5.8.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (_req, res) => {
+  res.json({ message: 'API is running' });
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});
+
+export default app;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "module": "commonjs",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a basic Express server in TypeScript
- compile configuration with `tsconfig.json`
- expand `package.json` to include dev, build, start, test and clean scripts

## Testing
- `npm run build` *(fails: rimraf not found)*
- `npm run dev` *(fails: ts-node not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a0bf9ed883239bc012afc9642a41