### PR TITLE
Add nodemon dev setup

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,5 @@
+{
+  "watch": ["src"],
+  "ext": "ts",
+  "exec": "ts-node ./src/index.ts"
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && tsc",
-    "dev": "ts-node src/index.ts",
+    "dev": "nodemon",
     "start": "npm run build && node dist/index.js",
     "test": "jest"
   },
@@ -32,6 +32,7 @@
     "rimraf": "^5.0.5",
     "ts-jest": "^29.2.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "nodemon": "^3.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- configure `npm run dev` to use nodemon
- add a nodemon.json file for watching TS source files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run dev` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851a1f206948323ad91de39e2b46ee8